### PR TITLE
Security hardening: XSS fix, stronger KDF, CSP, and module cleanup

### DIFF
--- a/src/main/java/com/github/phoswald/secret/page/Application.java
+++ b/src/main/java/com/github/phoswald/secret/page/Application.java
@@ -139,7 +139,7 @@ public class Application {
 
     private SecretKey createKey(byte[] salt, char[] password) throws GeneralSecurityException {
         SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-        KeySpec keySpec = new PBEKeySpec(password, salt, 100000 /* iterationCount */, 256 /* keyLength */);
+        KeySpec keySpec = new PBEKeySpec(password, salt, 600000 /* iterationCount */, 256 /* keyLength */);
         SecretKey key1 = factory.generateSecret(keySpec);
         SecretKey key2 = new SecretKeySpec(key1.getEncoded(), "AES");
         return key2;

--- a/src/main/resources/html/crypto.js
+++ b/src/main/resources/html/crypto.js
@@ -122,9 +122,7 @@ document.querySelector("#decrypt").addEventListener("click", async function() {
         let key = await createKey(salt, password);
         let plainText = await decryptMessage(key, iv, cipherText);
         document.querySelector("#password").value = "";
-        let markdownElement = document.createElement("markdown-text");
-        document.querySelector("#plaintext").replaceChildren(markdownElement);
-        markdownElement.markdown = plainText;
+        document.querySelector("#plaintext").markdown = plainText;
         document.querySelector("#menu").remove();
     } catch(e) {
         console.log("exception", e);

--- a/src/main/resources/html/crypto.js
+++ b/src/main/resources/html/crypto.js
@@ -41,7 +41,7 @@ async function createKey(salt, password) {
         {
             name: "PBKDF2",
             salt,
-            iterations: 100000,
+            iterations: 600000,
             hash: "SHA-256",
         },
         keyMaterial,
@@ -93,10 +93,6 @@ async function decryptMessage(key, iv, cipherText) {
     return plainText;
 }
 
-function createMarkdownHtml(text) {
-    return "<markdown-text><script type='text/markdown'>\n" + text + "\n</script></markdown-text>";
-}
-
 document.querySelector("#encrypt").addEventListener("click", async function() {
     try {
         let password = document.querySelector("#password").value;
@@ -126,7 +122,9 @@ document.querySelector("#decrypt").addEventListener("click", async function() {
         let key = await createKey(salt, password);
         let plainText = await decryptMessage(key, iv, cipherText);
         document.querySelector("#password").value = "";
-        document.querySelector("#plaintext").innerHTML = createMarkdownHtml(plainText);
+        let markdownElement = document.createElement("markdown-text");
+        document.querySelector("#plaintext").replaceChildren(markdownElement);
+        markdownElement.markdown = plainText;
         document.querySelector("#menu").remove();
     } catch(e) {
         console.log("exception", e);

--- a/src/main/resources/html/defaults.css
+++ b/src/main/resources/html/defaults.css
@@ -5,10 +5,6 @@
   --font-mono:  ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
 }
 
-.hidden {
-  display: none;
-}
-
 /* block elements */
 
 html, body, div, h1, h2, h3, h4, h5, h6, p, blockquote, pre, ol, ul, li, table, thead, tbody, tr, th, td {
@@ -139,4 +135,10 @@ input, button, textarea, select {
 textarea {
   vertical-align: top;
   overflow: auto;
+}
+
+/* utilities */
+
+.hidden {
+  display: none;
 }

--- a/src/main/resources/html/defaults.css
+++ b/src/main/resources/html/defaults.css
@@ -5,6 +5,10 @@
   --font-mono:  ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
 }
 
+.hidden {
+  display: none;
+}
+
 /* block elements */
 
 html, body, div, h1, h2, h3, h4, h5, h6, p, blockquote, pre, ol, ul, li, table, thead, tbody, tr, th, td {

--- a/src/main/resources/html/markdown.js
+++ b/src/main/resources/html/markdown.js
@@ -13,10 +13,18 @@ class MarkdownTextElement extends HTMLElement {
                 .then(response => response.text())
                 .then(text => this._renderMarkdown(text))
                 .catch(err => console.error('Failed to load:', err));
-        } else {
-            const text = this.querySelector('script[type="text/markdown"]')?.textContent ?? '';
-            this._renderMarkdown(this._dedent(text));
+            return;
         }
+        const script = this.querySelector('script[type="text/markdown"]');
+        if (script) {
+            this._renderMarkdown(this._dedent(script.textContent));
+        }
+    }
+
+    // Render markdown supplied programmatically as a plain string.
+    // The text is never serialized to HTML, so it cannot break out of any markup.
+    set markdown(value) {
+        this._renderMarkdown(value);
     }
 
     // Strip the minimum indentation found across all non-empty lines 

--- a/src/main/resources/html/template.html
+++ b/src/main/resources/html/template.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="secret-page/defaults.css">
   <link rel="stylesheet" href="secret-page/markdown.css">
   <script src="secret-page/markdown.js" type="module"></script>
+  <script src="secret-page/crypto.js" type="module"></script>
 </head>
 <body>
   <p id="menu">
@@ -25,6 +26,5 @@
     ${CIPHERTEXT}
   </div>
   <markdown-text id="plaintext"></markdown-text>
-  <script src="secret-page/crypto.js"></script>
 </body>
 </html>

--- a/src/main/resources/html/template.html
+++ b/src/main/resources/html/template.html
@@ -24,7 +24,7 @@
   <div id="cipherText" class="hidden">
     ${CIPHERTEXT}
   </div>
-  <div id="plaintext"></div>
+  <markdown-text id="plaintext"></markdown-text>
   <script src="secret-page/crypto.js"></script>
 </body>
 </html>

--- a/src/main/resources/html/template.html
+++ b/src/main/resources/html/template.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; base-uri 'none'; form-action 'none'">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${NAME}</title>
   <link rel="icon" href="secret-page/secret.ico">
@@ -14,12 +16,12 @@
     <input type="password" id="password" placeholder="Password">
     <input type="button" id="decrypt" value="Decrypt"><br>
     <!-- enable if desired -->
-    <span style="display: none;">
+    <span class="hidden">
       <textarea id="plaintext-input" rows="20" cols="80" placeholder="Plaintext"></textarea><br>
       <input type="button" id="encrypt" value="Encrypt">
     </span>
   </p>
-  <div id="cipherText" style="display: none;">
+  <div id="cipherText" class="hidden">
     ${CIPHERTEXT}
   </div>
   <div id="plaintext"></div>


### PR DESCRIPTION
 ## Summary
 
  Security hardening for the client-side decrypt page, plus related cleanups. Per
  the agreed threat model, the viewer must trust the served `*.js`; this PR shrinks
  the remaining attack surface and fixes a concrete sanitizer bypass.
 
  ### Changes

  1. **Fix DOMPurify-bypass XSS in the decrypt path** (`crypto.js`, `markdown.js`)
     The handler built an HTML string and assigned it via `innerHTML`, so a
     decrypted payload containing `</script><img src=x onerror=...>` broke out of
     the `<script type="text/markdown">` carrier and injected live, unsanitized
     DOM. The plaintext is now handed to `<markdown-text>` via a new `markdown`
     property (string → `marked.parse` → `dompurify.sanitize`), never touching an
     HTML parser.
 
  2. **Raise PBKDF2 iterations 100k → 600k** (`Application.java`, `crypto.js`)
     Current OWASP minimum for PBKDF2-HMAC-SHA256, kept in sync between Java
     encryption and JS decryption. Each page bundles its matching `crypto.js`, so
     no backward-compat concern.

  3. **Add a Content-Security-Policy** (`template.html`, `defaults.css`)
     `<meta>` CSP with strict `script-src 'self'` / `style-src 'self'` (no
     `'unsafe-inline'`/`'unsafe-eval'`) as defense-in-depth. Verified the bundled
     libs use no `eval`/`Function` and the CSS has no external refs. Two inline
     `display:none` styles moved to a `.hidden` class.
     
  4. **Simplify the decrypt target** (`template.html`, `crypto.js`)
     `#plaintext` is now the `<markdown-text>` element directly; the handler just
     sets `#plaintext.markdown = plainText`.
     
  5. **Load `crypto.js` as an ES module in `<head>`** (`template.html`)
     Consistency with `markdown.js`; keeps helpers out of global scope.
    
  ## Verification

  Verified end-to-end with headless Chrome (Playwright) and `mvn test` (4/4):
  - Exploit payload renders inert (`onerror` stripped, no execution).
  - Java(600k) ↔ JS(600k) round-trip decrypts correctly.
  - CSP enforced: zero violations on the legit flow; injected inline script blocked.
  - `src` and inline-`<script>` use cases still render; decrypt works with the
    head-loaded module.
